### PR TITLE
fix: fix cleanup regex newlines checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const stylelint = require('stylelint');
 const ruleName = 'plugin/license-header';
 const messages = stylelint.utils.ruleMessages(ruleName, { rejected: 'Invalid license header' });
 
-const CLEANUP_REGEX = /[\/**\/\n ]/;
+const CLEANUP_REGEX = /[\/**\/\r?\n|\r ]/;
 
 function readLicenseFile(path) {
   if (!path) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-plugin-license-header",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A plugin to validate the presence of/add license header in style files.",
   "main": "index.js",
   "publishConfig": { "registry": "https://registry.npmjs.org/" },


### PR DESCRIPTION
Update the `CLEANUP_REGEX` to handle Carriage Return (CR), Line Feed (LF) and CR followed by LF.