### PR TITLE
Preserving trailing new lines from the template file

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,34 @@ function readLicenseFile(path) {
   }
 }
 
+function countNewLines(text, newLine, side) {
+  if (!['left', 'right'].includes(side)) {
+    throw new Error(`invalid side <${side}>, unable to count new lines`);
+  }
+
+  if (side === 'right') {
+      text = text.split('').reverse().join('');
+      newLine = newLine.split('').reverse().join('');
+  }
+
+  let newLinesCount = 0;
+
+  for (let i = 0; i < text.length;) {
+      // Support both "\n" and "\r\n"
+      for (let y = 0; y < newLine.length; ++y) {
+          if (text.charAt(i) !== newLine.charAt(y)) {
+              return newLinesCount;
+          }
+
+          ++i;
+      }
+
+      ++newLinesCount;
+  }
+
+  return newLinesCount;
+}
+
 const newLicenseHeader = (primaryOptions, secondaryOptions = {}, context) => (postcssRoot, postcssResult) => {
   const validOptions = stylelint.utils.validateOptions(
     postcssResult,
@@ -41,11 +69,33 @@ const newLicenseHeader = (primaryOptions, secondaryOptions = {}, context) => (po
 
     const licenseHeader = readLicenseFile(secondaryOptions.license);
 
+    // Count trailing new lines to keep them after the header comment
+    const trailingNewLinesCount = countNewLines(
+        licenseHeader,
+        context.newline,
+        'right',
+    ) + 1; // always add at least one
+
     if (firstComment) {
       const licenseHeaderText = licenseHeader.replace(new RegExp(CLEANUP_REGEX, 'g'), '');
       const firstCommentText = firstComment.text.replace(new RegExp(CLEANUP_REGEX, 'g'), '');
+      let newLinesAfterFirstComment = countNewLines(
+          firstComment.raws.after || '',
+          context.newline,
+          'right',
+      );
 
-      if (firstCommentText === licenseHeaderText) return;
+
+      // Also count new lines before the next node (if any)
+      if (firstComment.next()) {
+        newLinesAfterFirstComment += countNewLines(
+            firstComment.next().raws.before || '',
+            context.newline,
+            'left',
+        );
+      }
+
+      if (firstCommentText === licenseHeaderText && trailingNewLinesCount === newLinesAfterFirstComment) return;
 
       if (firstComment.parent === postcssRoot) {
         firstComment.remove();
@@ -54,6 +104,15 @@ const newLicenseHeader = (primaryOptions, secondaryOptions = {}, context) => (po
 
     if (context.fix) {
       postcssRoot.prepend(licenseHeader);
+
+      const nextNode = postcssRoot.nodes[1];
+
+      if (nextNode) {
+        const existingBefore = nextNode.raws.before || '';
+
+        nextNode.raws.before = context.newline.repeat(trailingNewLinesCount) + existingBefore;
+      }
+
       return;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-plugin-license-header",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A plugin to validate the presence of/add license header in style files.",
   "main": "index.js",
   "publishConfig": { "registry": "https://registry.npmjs.org/" },


### PR DESCRIPTION
This PR preserves any trailing new line from the template file while checking/fixing the header comments.

I changed the package version to `1.0.3` to save you some time, please let me know if you want me to change it.

### Example template:
```js
/*
 * This is my template
 */
 
```

### Example source file:
```js
// Bad header comment
console.log('Hello world');
```

### Expected output:
```js
/*
 * This is my template
 */

console.log('Hello world');
```

### Output without this PR:
```js
/*
 * This is my template
 */
console.log('Hello world');
```

I hope you find this useful, please feel free to ask for changes or further information.

Thank you for your time.